### PR TITLE
エラーメッセージの日本語化の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ gem 'pry-rails'
 gem 'jquery-rails'
 
 gem'thinreports'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.2)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.4)
       actionpack (= 6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -295,6 +298,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails
   rubocop
   sass-rails (~> 5)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,8 @@ class User < ApplicationRecord
   with_options presence: true do
     validates :name
     validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze, message: 'は半角かつ英数を両方含む必要があります' }
-    validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
-    validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
+    validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "は不正な値です"}
+    validates :prefecture_id, numericality: {other_than: 1, message: "を選択してください"}
     validates :city
     validates :address
     validates :phone_number,format: { with: /\A[0-9]{10,11}\z/}

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module EasySlips
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        name: 会社名・個人事業主名
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        phone_number: 電話番号
+      slip:
+        address_name: 出荷先
+        shipping_date: 出荷日
+        slip_number: 伝票番号
+        invoice_number: 送り状ナンバー
+      slip/orders:
+        note: 備考

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -6,20 +6,7 @@ RSpec.describe Order, type: :model do
   end
     
   describe '出荷商品登録' do
-    context '出荷商品を登録できる場合' do
-      it 'orderのnoteが20文字以下であれば登録できる' do
-        @order.note = 'あいうえおかきくけこさしすせそたちつてと'
-        expect(@order).to be_valid
-      end
-    end
-  
     context '出荷商品を登録できない場合' do
-      it 'orderのnoteが20文字より多い場合登録できない' do
-        @order.note = 'あいうえおかきくけこさしすせそたちつてとな'
-        @order.valid?
-        expect(@order.errors.full_messages).to include("Note is too long (maximum is 20 characters)")
-      end
-
       it '伝票が紐づいていなければ登録できない' do
         @order.slip = nil
         @order.valid?

--- a/spec/models/slip_spec.rb
+++ b/spec/models/slip_spec.rb
@@ -28,37 +28,48 @@ RSpec.describe Slip, type: :model do
         @slip.invoice_number = 1111111111
         expect(@slip).to be_valid
       end
+
+      it 'orderのnoteが20文字以下であれば登録できる' do
+        @order.note = 'あいうえおかきくけこさしすせそたちつてと'
+        expect(@slip).to be_valid
+      end
     end
 
     context '作成した伝票を登録できない場合' do
       it 'address_nameが空では登録できない' do
         @slip.address_name = ''
         @slip.valid?
-        expect(@slip.errors.full_messages).to include("Address name can't be blank")
+        expect(@slip.errors.full_messages).to include("出荷先を入力してください")
       end
 
       it 'shipping_dateが空では登録できない' do
         @slip.shipping_date = ''
         @slip.valid?
-        expect(@slip.errors.full_messages).to include("Shipping date can't be blank")
+        expect(@slip.errors.full_messages).to include("出荷日を入力してください")
       end
       
       it 'slip_numberが空では登録できない' do
         @slip.slip_number = ''
         @slip.valid?
-        expect(@slip.errors.full_messages).to include("Slip number can't be blank")
+        expect(@slip.errors.full_messages).to include("伝票番号を入力してください")
       end
 
       it 'slip_numberが11桁以上では登録できない' do
         @slip.slip_number = 11111111111
         @slip.valid?
-        expect(@slip.errors.full_messages).to include("Slip number is too long (maximum is 10 characters)")
+        expect(@slip.errors.full_messages).to include("伝票番号は10文字以内で入力してください")
       end
 
       it 'invoice_numberが11桁以上では登録できない' do
         @slip.invoice_number = 11111111111
         @slip.valid?
-        expect(@slip.errors.full_messages).to include("Invoice number is too long (maximum is 10 characters)")
+        expect(@slip.errors.full_messages).to include("送り状ナンバーは10文字以内で入力してください")
+      end
+
+      it 'orderのnoteが20文字より多い場合登録できない' do
+        @order.note = 'あいうえおかきくけこさしすせそたちつてとな'
+        @slip.valid?
+        expect(@slip.errors.full_messages).to include("備考は20文字以内で入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,124 +25,124 @@ RSpec.describe User, type: :model do
       it 'nameが空では登録できない' do
         @user.name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Name can't be blank")
+        expect(@user.errors.full_messages).to include("会社名・個人事業主名を入力してください")
       end
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it '重複したemailが存在する場合登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
       it 'メールアドレスに@を含まない場合は登録できない ' do
         @user.email = 'abc123.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'passwordが5文字以下であれば登録できない' do
         @user.password = 'aaa11'
         @user.password_confirmation = 'aaa11'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password = 'aaa111'
         @user.password_confirmation = 'aaa112'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
       it 'passwordが英字のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password は半角かつ英数を両方含む必要があります')
+        expect(@user.errors.full_messages).to include('パスワードは半角かつ英数を両方含む必要があります')
       end
       it 'passwordが数字のみでは登録できない' do
         @user.password = '111111'
         @user.password_confirmation = '111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password は半角かつ英数を両方含む必要があります')
+        expect(@user.errors.full_messages).to include('パスワードは半角かつ英数を両方含む必要があります')
       end
       it '全角文字を含むパスワードでは登録できない' do
         @user.password = 'ａｂｃ111aaa'
         @user.password_confirmation = 'ａｂｃ111aaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password は半角かつ英数を両方含む必要があります')
+        expect(@user.errors.full_messages).to include('パスワードは半角かつ英数を両方含む必要があります')
       end
       it 'postal_codeが空では保存できないこと' do
         @user.postal_code = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Postal code can't be blank")
+        expect(@user.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'postal_codeが「3桁-4桁」のフォーマットでなければ保存できないこと' do
         @user.postal_code = '1111-222'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Postal code is invalid. Include hyphen(-)")
+        expect(@user.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it 'postal_codeが半角でなければ保存できないこと' do
         @user.postal_code = '１１１-２２２'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Postal code is invalid. Include hyphen(-)")
+        expect(@user.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it 'postal_codeがハイフンなしでは保存できないこと' do
         @user.postal_code = '1112222'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Postal code is invalid. Include hyphen(-)")
+        expect(@user.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it 'prefecture_idが空では保存できないこと' do
         @user.prefecture_id = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@user.errors.full_messages).to include("都道府県を選択してください")
       end
       it 'prefecture_idが1では保存できないこと' do
         @user.prefecture_id = 1
         @user.valid?
-        expect(@user.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@user.errors.full_messages).to include("都道府県を選択してください")
       end
       it 'cityが空では保存できないこと' do
         @user.city = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("City can't be blank")
+        expect(@user.errors.full_messages).to include("市区町村を入力してください")
       end
       it 'addressが空では保存できないこと' do
         @user.address = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Address can't be blank")
+        expect(@user.errors.full_messages).to include("番地を入力してください")
       end
       it 'phone_numberが空では保存できないこと' do
         @user.phone_number = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Phone number can't be blank")
+        expect(@user.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'phone_numberにハイフンが含まれている状態では保存できないこと' do
         @user.phone_number = '09-12345678'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Phone number is invalid")
+        expect(@user.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが全角では保存できないこと' do
         @user.phone_number = '０９０１２３４５６７８'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Phone number is invalid")
+        expect(@user.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが9桁以下では保存できないこと' do
         @user.phone_number = '090123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Phone number is invalid")
+        expect(@user.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが12桁以上では保存できないこと' do
         @user.phone_number = '090123456789'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Phone number is invalid")
+        expect(@user.errors.full_messages).to include("電話番号は不正な値です")
       end
     end
   end


### PR DESCRIPTION
#What
エラーメッセージの日本語化の実装

#Why
フォームの入力誤りがあった際に、ユーザーが原因を理解しやすくするため。